### PR TITLE
Add SensorStateClass to termperature and humidity sensors

### DIFF
--- a/custom_components/tiko/classes/TikoHumiditySensor.py
+++ b/custom_components/tiko/classes/TikoHumiditySensor.py
@@ -5,6 +5,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
+    SensorStateClass,
 )
 from homeassistant.const import PERCENTAGE
 
@@ -63,6 +64,11 @@ class TikoHumiditySensor(CoordinatorEntity, SensorEntity):
     def device_class(self):
         """Returns the type of value that is being measured."""
         return SensorDeviceClass.HUMIDITY
+
+    @property
+    def state_class(self):
+        """Returns the state class of the sensor."""
+        return SensorStateClass.MEASUREMENT
 
     @property
     def native_unit_of_measurement(self):

--- a/custom_components/tiko/classes/TikoTemperatureSensor.py
+++ b/custom_components/tiko/classes/TikoTemperatureSensor.py
@@ -4,7 +4,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.const import UnitOfTemperature
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.const import PERCENTAGE
 
 from ..const import DOMAIN
@@ -90,6 +90,11 @@ class TikoTemperatureSensor(CoordinatorEntity, SensorEntity):
     def device_class(self):
         """Returns the type of value that is being measured."""
         return SensorDeviceClass.TEMPERATURE
+
+    @property
+    def state_class(self):
+        """Returns the state class of the sensor."""
+        return SensorStateClass.MEASUREMENT
 
     @property
     def native_unit_of_measurement(self):


### PR DESCRIPTION
J'ai migré depuis un autre addon Tiko vers celui ci.
Cependant, je veux garder mes entités (et leur historique) existantes, et Home Assistant râlait en me disant qu'ils avaient perdu leur "state class".

Ce commit corrige ce soucis.